### PR TITLE
fixed typo in the 2.5 Dependencies section

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -337,7 +337,7 @@ your `deps.edn` file.
 [,clojure]
 ----
 {:deps {org.clojure/clojure {:mvn/version "1.12.1"}
-        org.duct-framework/main {:mvn/version "0.2.1"}
+        org.duct-framework/main {:mvn/version "0.2.1"}}
  :aliases
  {:duct {:main-opts ["-m" "duct.main"]}
   :test {:extra-deps {org.duct-framework/test {:mvn/version "0.1.0"}}}}}


### PR DESCRIPTION
I added a missing closing curly bracket to make deps.edn valid